### PR TITLE
[JBPM-8280] Add SMILE-based prediction service examples

### DIFF
--- a/jbpm-recommendation-smile-naivebayes/README.md
+++ b/jbpm-recommendation-smile-naivebayes/README.md
@@ -1,0 +1,30 @@
+# jBPM SMILE naïve Bayes prediction service
+
+## Description
+
+This module contains an example implementation of a prediction service
+backend using a SMILE naïve Bayes-based example.
+
+The prediction service allows to set a model's predictions as the
+Human Task output. If the prediction's `confidence` is higher than the
+`confidenceThreshold` then the Human Task is automatically completed.
+
+ The example Human Task has three inputs (`actor`, `level`, `item`) and one output (`approved`).
+ 
+ The service can be configured using the following property files:
+ 
+ * `inputs.properties`, a key/value list of attribute name/attribute type (e.g. `item=NOMINAL` means `item` is a nominal attribute)
+ * `output.properties` contains the output attribute name and type and the confidence threshold
+
+ 
+ ## Installation
+ 
+ To install the service example simply build the JAR using
+ 
+ ```
+$ mvn clean install
+```
+
+and place it in the jBPM server's classpath.
+
+The example Human Task located in `test/resources/BPMN2-UserTask.bpmn2` can be imported into jBPM to run the example. 

--- a/jbpm-recommendation-smile-naivebayes/pom.xml
+++ b/jbpm-recommendation-smile-naivebayes/pom.xml
@@ -13,13 +13,18 @@
 
   <name>jBPM :: Prediction :: Naive Bayes based prediction service</name>
   <description>Naive Bayes based prediction service</description>
-  
+
+  <properties>
+    <smile.version>1.5.2</smile.version>
+  </properties>
+
+
   <dependencyManagement>
       <dependencies>
         <dependency>
           <groupId>com.github.haifengl</groupId>
           <artifactId>smile-core</artifactId>
-          <version>1.5.2</version>
+          <version>${smile.version}</version>
         </dependency>
       </dependencies>
     </dependencyManagement>

--- a/jbpm-recommendation-smile-naivebayes/pom.xml
+++ b/jbpm-recommendation-smile-naivebayes/pom.xml
@@ -1,0 +1,96 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm</artifactId>
+    <version>7.27.0.Final</version>
+    <relativePath></relativePath>
+  </parent>
+
+  <artifactId>jbpm-recommendation-smile-naivebayes</artifactId>
+
+  <name>jBPM :: Prediction :: Naive Bayes based prediction service</name>
+  <description>Naive Bayes based prediction service</description>
+  
+  <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.haifengl</groupId>
+          <artifactId>smile-core</artifactId>
+          <version>1.5.2</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-kie-services</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-entitymanager</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- javax.el required by hibernate-validator -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.el</groupId>
+      <artifactId>jboss-el-api_3.0_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.haifengl</groupId>
+      <artifactId>smile-core</artifactId>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AbstractPredictionEngine.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AbstractPredictionEngine.java
@@ -18,7 +18,7 @@ package org.jbpm.prediction.naivebayes;
 
 import java.util.Map;
 
-abstract public class AbstractPredictionEngine {
+public abstract class AbstractPredictionEngine {
 
     protected Map<String, AttributeType> inputFeatures;
     protected String outcomeFeatureName;

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AbstractPredictionEngine.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AbstractPredictionEngine.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import java.util.Map;
+
+abstract public class AbstractPredictionEngine {
+
+    protected Map<String, AttributeType> inputFeatures;
+    protected String outcomeFeatureName;
+    protected AttributeType outcomeFeatureType;
+    protected double confidenceThreshold;
+
+    public AbstractPredictionEngine(Map<String, AttributeType> inputFeatures, String outputFeatureName, AttributeType outputFeatureType, double confidenceThreshold) {
+        this.inputFeatures = inputFeatures;
+        this.outcomeFeatureName = outputFeatureName;
+        this.outcomeFeatureType = outputFeatureType;
+        this.confidenceThreshold = confidenceThreshold;
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AttributeType.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/AttributeType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+public enum AttributeType {
+    STRING,
+    NOMINAL,
+    NUMERIC
+}

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/NaiveBayesConfiguration.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/NaiveBayesConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Encapsulates the model's output information.
+ */
+public class NaiveBayesConfiguration {
+
+    private String outcomeName;
+    private AttributeType outcomeType;
+    private double confidenceThreshold;
+    private Map<String, AttributeType> inputFeatures = new HashMap<>();
+
+    /**
+     * Returns the name of the output attribute
+     *
+     * @return The name of the output attribute
+     */
+    public String getOutcomeName() {
+        return outcomeName;
+    }
+
+    public void setOutcomeName(String outcomeName) {
+        this.outcomeName = outcomeName;
+    }
+
+    /**
+     * Returns the type of the output attribute {@link AttributeType}
+     *
+     * @return The type of the output attribute
+     */
+    public AttributeType getOutcomeType() {
+        return outcomeType;
+    }
+
+    public void setOutcomeType(AttributeType outcomeType) {
+        this.outcomeType = outcomeType;
+    }
+
+    /**
+     * Returns the confidence threshold to use for automatic task completion
+     *
+     * @return The confidence threshold, between 0.0 and 1.0
+     */
+    public double getConfidenceThreshold() {
+        return confidenceThreshold;
+    }
+
+    public void setConfidenceThreshold(double confidenceThreshold) {
+        this.confidenceThreshold = confidenceThreshold;
+    }
+
+    public Map<String, AttributeType> getInputFeatures() {
+        return inputFeatures;
+    }
+
+    public void setInputFeatures(Map<String, AttributeType> inputFeatures) {
+        this.inputFeatures = inputFeatures;
+    }
+}

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/NaiveBayesRegistry.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/NaiveBayesRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.kie.internal.task.api.prediction.PredictionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+
+public class NaiveBayesRegistry {
+    private static final ServiceLoader<PredictionService> foundServices = ServiceLoader.load(PredictionService.class, NaiveBayesRegistry.class.getClassLoader());
+    private String selectedService = System.getProperty("org.jbpm.prediction.naivebayes", SmileNaiveBayes.IDENTIFIER);
+    private Map<String, PredictionService> predictionServices = new HashMap<>();
+
+    private NaiveBayesRegistry() {
+
+        foundServices
+                .forEach(strategy -> predictionServices.put(strategy.getIdentifier(), strategy));
+    }
+
+    public static NaiveBayesRegistry get() {
+        return Holder.INSTANCE;
+    }
+
+    public PredictionService getService() {
+        PredictionService predictionService = predictionServices.get(selectedService);
+        if (predictionService == null) {
+            throw new IllegalArgumentException("No prediction service was found with id " + selectedService);
+        }
+
+        return predictionService;
+    }
+
+    private static class Holder {
+        static final NaiveBayesRegistry INSTANCE = new NaiveBayesRegistry();
+    }
+
+    public synchronized void addStrategy(SmileNaiveBayes predictionService) {
+        this.predictionServices.put(predictionService.getIdentifier(), predictionService);
+
+    }
+}

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.kie.api.task.model.Task;
+import org.kie.internal.task.api.prediction.PredictionOutcome;
+import org.kie.internal.task.api.prediction.PredictionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import smile.classification.NaiveBayes;
+import smile.data.*;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.*;
+
+public class SmileNaiveBayes extends AbstractPredictionEngine implements PredictionService {
+
+    public static final String IDENTIFIER = "SMILENaiveBayes";
+
+    private static final Logger logger = LoggerFactory.getLogger(SmileNaiveBayes.class);
+
+    private final AttributeDataset dataset;
+    private final Map<String, Attribute> smileAttributes;
+    private final Attribute outcomeAttribute;
+    private final int numAttributes;
+    protected List<String> attributeNames = new ArrayList<>();
+    private NaiveBayes model = null;
+    private Set<String> outcomeSet = new HashSet<>();
+
+    public SmileNaiveBayes() {
+        this(readConfigurationFromFile());
+    }
+
+
+    public SmileNaiveBayes(NaiveBayesConfiguration configuration) {
+        this(configuration.getInputFeatures(),
+                configuration.getOutcomeName(),
+                configuration.getOutcomeType(),
+                configuration.getConfidenceThreshold());
+    }
+
+    public SmileNaiveBayes(Map<String, AttributeType> inputFeatures, String outputFeatureName, AttributeType outputFeatureType, double confidenceThreshold) {
+        super(inputFeatures, outputFeatureName, outputFeatureType, confidenceThreshold);
+        smileAttributes = new HashMap<>();
+        for (Map.Entry<String, AttributeType> inputFeature : inputFeatures.entrySet()) {
+            final String name = inputFeature.getKey();
+            final AttributeType type = inputFeature.getValue();
+            smileAttributes.put(name, createAttribute(name, type));
+            attributeNames.add(name);
+        }
+        numAttributes = smileAttributes.size();
+        outcomeAttribute = createAttribute(outcomeFeatureName, outputFeatureType);
+        dataset = new AttributeDataset("dataset", smileAttributes.values().toArray(new Attribute[numAttributes]), outcomeAttribute);
+    }
+
+    /**
+     * Reads the naive bayes configuration from properties files.
+     * "inputs.properties" should contain the input attribute names as keys and attribute types as values.
+     *
+     * @return A map of input attributes with the attribute name as key and attribute type as value.
+     */
+    private static NaiveBayesConfiguration readConfigurationFromFile() {
+
+        final NaiveBayesConfiguration configuration = new NaiveBayesConfiguration();
+
+        InputStream inputStream = null;
+        final Map<String, AttributeType> inputFeatures = new HashMap<>();
+        try {
+            Properties prop = new Properties();
+
+            inputStream = SmileNaiveBayes.class.getClassLoader().getResourceAsStream("inputs.properties");
+
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("Could not find the property file 'inputs.properties' in the classpath.");
+            }
+
+            for (Object propertyName : prop.keySet()) {
+                inputFeatures.put((String) propertyName, AttributeType.valueOf(prop.getProperty((String) propertyName)));
+            }
+
+        } catch (Exception e) {
+            logger.error("Exception: " + e);
+        }
+        configuration.setInputFeatures(inputFeatures);
+
+        try {
+            Properties prop = new Properties();
+
+            inputStream = SmileNaiveBayes.class.getClassLoader().getResourceAsStream("output.properties");
+
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("Could not find the property file 'output.properties' in the classpath.");
+            }
+
+            configuration.setOutcomeName(prop.getProperty("name"));
+            configuration.setOutcomeType(AttributeType.valueOf(prop.getProperty("type")));
+            configuration.setConfidenceThreshold(Double.parseDouble(prop.getProperty("confidence_threshold")));
+        } catch (Exception e) {
+            logger.error("Exception: " + e);
+        }
+        return configuration;
+    }
+
+    private static Attribute createAttribute(String name, AttributeType type) {
+        if (type == AttributeType.NOMINAL) {
+            return new NominalAttribute(name);
+        } else if (type == AttributeType.NUMERIC) {
+            return new NumericAttribute(name);
+        } else {
+            return new StringAttribute(name);
+        }
+    }
+
+    /**
+     * Add the data provided as a map to a Smile {@link smile.data.Dataset}.
+     *
+     * @param data    A map containing the input attribute names as keys and the attribute values as values.
+     * @param outcome The value of the outcome (output data).
+     */
+    public void addData(Map<String, Object> data, Object outcome) {
+        final double[] features = new double[numAttributes];
+        int i = 0;
+        for (String attrName : smileAttributes.keySet()) {
+            try {
+                features[i] = smileAttributes.get(attrName).valueOf(data.get(attrName).toString());
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+            i++;
+        }
+        try {
+            final String outcomeStr = outcome.toString();
+            outcomeSet.add(outcomeStr);
+            dataset.add(features, outcomeAttribute.valueOf(outcomeStr));
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Build a set of features compatible with Smile's datasets from the map of input data
+     *
+     * @param data A map containing the input attribute names as keys and the attribute values as values.
+     * @return A feature vector as a array of doubles.
+     */
+    protected double[] buildFeatures(Map<String, Object> data) {
+        final double[] features = new double[numAttributes];
+        for (int i = 0; i < numAttributes; i++) {
+            final String attrName = attributeNames.get(i);
+            try {
+                features[i] = smileAttributes.get(attrName).valueOf(data.get(attrName).toString());
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return features;
+    }
+
+
+    /**
+     * Returns the service's identifier
+     *
+     * @return The service identifier
+     */
+    @Override
+    public String getIdentifier() {
+        return IDENTIFIER;
+    }
+
+    /**
+     * Returns a model prediction given the input data
+     *
+     * @param task      Human task data
+     * @param inputData A map containing the input attribute names as keys and the attribute values as values.
+     * @return A {@link PredictionOutcome} containing the model's prediction for the input data.
+     */
+    @Override
+    public PredictionOutcome predict(Task task, Map<String, Object> inputData) {
+        Map<String, Object> outcomes = new HashMap<>();
+        if (outcomeSet.size() >= 2) {
+            model = new NaiveBayes(NaiveBayes.Model.MULTINOMIAL, outcomeSet.size(), attributeNames.size());
+
+            int[] y = new int[dataset.size()];
+            for (int i = 0; i < dataset.size(); i++) {
+
+                y[i] = (int) dataset.get(i).y;
+            }
+
+            model.learn(dataset.x(), y);
+            final double[] features = buildFeatures(inputData);
+            final double[] posteriori = new double[outcomeSet.size()];
+            double prediction = model.predict(features, posteriori);
+
+            if (prediction != -1.0) {
+
+                String predictionStr = dataset.responseAttribute().toString(prediction);
+                outcomes.put(outcomeAttribute.getName(), predictionStr);
+                final double confidence = posteriori[(int) prediction];
+
+                outcomes.put("confidence", confidence);
+
+                logger.debug(inputData + ", prediction = " + predictionStr + ", confidence = " + confidence);
+
+                return new PredictionOutcome(confidence, this.confidenceThreshold, outcomes);
+            } else {
+                return new PredictionOutcome(0.0, this.confidenceThreshold, outcomes);
+            }
+
+        } else {
+            return new PredictionOutcome(0.0, this.confidenceThreshold, outcomes);
+        }
+    }
+
+    /**
+     * Train the naive bayes model using data from the human task.
+     *
+     * @param task       Human task data
+     * @param inputData  A map containing the input attribute names as keys and the attribute values as values.
+     * @param outputData A map containing the output attribute names as keys and the attribute values as values.
+     */
+    @Override
+    public void train(Task task, Map<String, Object> inputData, Map<String, Object> outputData) {
+        addData(inputData, outputData.get(outcomeAttribute.getName()));
+    }
+}

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
@@ -99,7 +99,15 @@ public class SmileNaiveBayes extends AbstractPredictionEngine implements Predict
         } catch (Exception e) {
             logger.error("Exception: " + e);
         }
-        configuration.setInputFeatures(inputFeatures);
+
+        // check input configuration is appropriate for this concrete example
+        if (inputFeatures.containsKey("item") && inputFeatures.get("item")==AttributeType.NOMINAL &&
+                inputFeatures.containsKey("ActorId") && inputFeatures.get("ActorId")==AttributeType.NOMINAL &&
+                inputFeatures.containsKey("level") && inputFeatures.get("level")==AttributeType.NOMINAL) {
+            configuration.setInputFeatures(inputFeatures);
+        } else {
+            throw new IllegalArgumentException("Required inputs not properly specified.");
+        }
 
         try {
             Properties prop = new Properties();
@@ -112,9 +120,21 @@ public class SmileNaiveBayes extends AbstractPredictionEngine implements Predict
                 throw new FileNotFoundException("Could not find the property file 'output.properties' in the classpath.");
             }
 
-            configuration.setOutcomeName(prop.getProperty("name"));
-            configuration.setOutcomeType(AttributeType.valueOf(prop.getProperty("type")));
-            configuration.setConfidenceThreshold(Double.parseDouble(prop.getProperty("confidence_threshold")));
+            // check input configuration is appropriate for this concrete example
+            if (prop.containsKey("name") && prop.get("name").equals("approved") &&
+                    prop.containsKey("type") && prop.get("type").equals("NOMINAL") &&
+                    prop.containsKey("confidence_threshold")) {
+
+                configuration.setOutcomeName(prop.getProperty("name"));
+                configuration.setOutcomeType(AttributeType.valueOf(prop.getProperty("type")));
+                try {
+                    configuration.setConfidenceThreshold(Double.parseDouble(prop.getProperty("confidence_threshold")));
+                } catch (NumberFormatException e) {
+                    logger.error("Invalid numerical value in output.properties");
+                }
+            } else {
+                throw new IllegalArgumentException("Required outputs not properly specified.");
+            }
         } catch (Exception e) {
             logger.error("Exception: " + e);
         }
@@ -140,20 +160,21 @@ public class SmileNaiveBayes extends AbstractPredictionEngine implements Predict
     public void addData(Map<String, Object> data, Object outcome) {
         final double[] features = new double[numAttributes];
         int i = 0;
-        for (String attrName : smileAttributes.keySet()) {
+        for (Map.Entry<String, Attribute> attribute : smileAttributes.entrySet()) {
+            final String datum = data.get(attribute.getKey()).toString();
             try {
-                features[i] = smileAttributes.get(attrName).valueOf(data.get(attrName).toString());
+                features[i] = attribute.getValue().valueOf(datum);
             } catch (ParseException e) {
-                e.printStackTrace();
+                logger.error(String.format("Error parsing the value of %s: '%s'", attribute.getKey(), datum));
             }
             i++;
         }
+        final String outcomeStr = outcome.toString();
         try {
-            final String outcomeStr = outcome.toString();
             outcomeSet.add(outcomeStr);
             dataset.add(features, outcomeAttribute.valueOf(outcomeStr));
         } catch (ParseException e) {
-            e.printStackTrace();
+            logger.error(String.format("Error parsing the outcome value: %s", outcomeStr));
         }
     }
 

--- a/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
+++ b/jbpm-recommendation-smile-naivebayes/src/main/java/org/jbpm/prediction/naivebayes/SmileNaiveBayes.java
@@ -217,6 +217,19 @@ public class SmileNaiveBayes extends AbstractPredictionEngine implements Predict
      */
     @Override
     public PredictionOutcome predict(Task task, Map<String, Object> inputData) {
+
+        // Allow confidence threshold to be overriden by a Java property
+        final String confidenceThreshold = System.getProperty("org.jbpm.task.prediction.service.confidence_threshold");
+
+        // Check if the confidence threshold was set at runtime, otherwise keep using as defined in output.properties
+        if (confidenceThreshold!=null) {
+            try {
+                this.confidenceThreshold = Double.parseDouble(confidenceThreshold);
+            } catch (NumberFormatException e) {
+                logger.error("Invalid confidence threshold set in org.jbpm.task.prediction.service.confidence_threshold");
+            }
+        }
+
         Map<String, Object> outcomes = new HashMap<>();
         if (outcomeSet.size() >= 2) {
             model = new NaiveBayes(NaiveBayes.Model.MULTINOMIAL, outcomeSet.size(), attributeNames.size());

--- a/jbpm-recommendation-smile-naivebayes/src/main/resources/META-INF/services/org.kie.internal.task.api.prediction.PredictionService
+++ b/jbpm-recommendation-smile-naivebayes/src/main/resources/META-INF/services/org.kie.internal.task.api.prediction.PredictionService
@@ -1,0 +1,1 @@
+org.jbpm.prediction.naivebayes.SmileNaiveBayes

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/NaiveBayesRecommendationServiceProcessTest.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/NaiveBayesRecommendationServiceProcessTest.java
@@ -81,6 +81,6 @@ public abstract class NaiveBayesRecommendationServiceProcessTest extends Abstrac
             return outputs;
         }
 
-        return null;
+        return new HashMap<>();
     }
 }

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/NaiveBayesRecommendationServiceProcessTest.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/NaiveBayesRecommendationServiceProcessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.test.services.AbstractKieServicesTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.kie.api.task.model.TaskSummary;
+import org.kie.internal.query.QueryFilter;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertNotNull;
+
+public abstract class NaiveBayesRecommendationServiceProcessTest extends AbstractKieServicesTest {
+
+    private Logger LOGGER = Logger.getLogger(NaiveBayesRecommendationServiceProcessTest.class.getName());
+
+    private List<Long> instances = new ArrayList<>();
+
+    @BeforeClass
+    public static void setupOnce() {
+        System.setProperty("org.jbpm.task.prediction.service", SmileNaiveBayes.IDENTIFIER);
+    }
+
+    @AfterClass
+    public static void cleanOnce() {
+        System.clearProperty("org.jbpm.task.prediction.service");
+    }
+
+    @Override
+    protected List<String> getProcessDefinitionFiles() {
+        List<String> processes = new ArrayList<String>();
+        processes.add("BPMN2-UserTask.bpmn2");
+        return processes;
+    }
+
+    @Override
+    public DeploymentUnit prepareDeploymentUnit() throws Exception {
+        // specify GROUP_ID, ARTIFACT_ID, VERSION of your kjar
+        return createAndDeployUnit("org.jbpm.test.prediction", "naive-bayes-test", "1.0.0");
+    }
+
+
+    protected Map<String, Object> startAndReturnTaskOutputData(String item, String userId, Integer level, Boolean approved) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("item", item);
+        parameters.put("level", level);
+        parameters.put("actor", userId);
+        long processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "UserTask", parameters);
+        instances.add(processInstanceId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksByStatusByProcessInstanceId(processInstanceId, null, new QueryFilter());
+        assertNotNull(tasks);
+
+        if (!tasks.isEmpty()) {
+
+            Long taskId = tasks.get(0).getId();
+
+            Map<String, Object> outputs = userTaskService.getTaskOutputContentByTaskId(taskId);
+            assertNotNull(outputs);
+
+            userTaskService.completeAutoProgress(taskId, userId, Collections.singletonMap("approved", approved));
+
+            return outputs;
+        }
+
+        return null;
+    }
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
@@ -29,7 +29,7 @@ public class Series1Test extends NaiveBayesRecommendationServiceProcessTest {
      * shows how after passing min count of 2 input, accuracy goes to > 0.95 (95%) very quickly.
      */
     @Test
-    public void test1() {
+    public void testHighConfidenceWithSmallDataset() {
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 30; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
@@ -30,6 +30,7 @@ public class Series1Test extends NaiveBayesRecommendationServiceProcessTest {
      */
     @Test
     public void testHighConfidenceWithSmallDataset() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 30; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series1Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series1Test extends NaiveBayesRecommendationServiceProcessTest {
+    /**
+     * shows how after passing min count of 2 input, accuracy goes to > 0.95 (95%) very quickly.
+     */
+    @Test
+    public void test1() {
+        Map<String, Object> outputs = new HashMap<>();
+
+        for (int i = 0; i < 30; i++) {
+            startAndReturnTaskOutputData("test item", "john", 5, false);
+            outputs = startAndReturnTaskOutputData("test item", "mary", 5, true);
+        }
+        assertTrue((double) outputs.get("confidence") > 0.7);
+        assertEquals("true", outputs.get("approved"));
+
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series2Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series2Test.java
@@ -30,7 +30,7 @@ public class Series2Test extends NaiveBayesRecommendationServiceProcessTest {
      * values, it takes a while longer to get to high accuracy
      */
     @Test
-    public void test2() {
+    public void testPredictionWithHighVaryingParameter() {
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series2Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series2Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series2Test extends NaiveBayesRecommendationServiceProcessTest {
+    /**
+     * This test shows how after passing min count of 2 input with 1 irrelevant param switching between 5 possible
+     * values, it takes a while longer to get to high accuracy
+     */
+    @Test
+    public void test2() {
+        Map<String, Object> outputs = new HashMap<>();
+
+        for (int i = 0; i < 50; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, false);
+            outputs = startAndReturnTaskOutputData("test item", "mary", i % 5, true);
+        }
+        assertTrue((double) outputs.get("confidence") > 0.7);
+        assertEquals("true", outputs.get("approved"));
+
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series3Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series3Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series3Test extends NaiveBayesRecommendationServiceProcessTest {
+    /**
+     * This test shows how the accuracy goes extremely quickly to 1.0 (100.0%) if you give it the same result initially
+     * it does not even respond to different inputs
+     */
+    @Test
+    public void test3() {
+        Map<String, Object> outputs;
+
+        for (int i = 0; i < 10; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, false);
+        }
+        startAndReturnTaskOutputData("test item2", "mary", 10, true);
+        outputs = startAndReturnTaskOutputData("test item2", "mary", 10, true);
+
+        assertEquals("true", outputs.get("approved"));
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series3Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series3Test.java
@@ -29,7 +29,7 @@ public class Series3Test extends NaiveBayesRecommendationServiceProcessTest {
      * it does not even respond to different inputs
      */
     @Test
-    public void test3() {
+    public void testOutcomeWithPreviouslyUnseenInputData() {
         Map<String, Object> outputs;
 
         for (int i = 0; i < 10; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
@@ -30,6 +30,7 @@ public class Series4Test extends NaiveBayesRecommendationServiceProcessTest {
      */
     @Test
     public void testHighPredictionConfidenceWithVaryingParameter() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series4Test extends NaiveBayesRecommendationServiceProcessTest {
+    /**
+     * This test shows how after passing min count of 2 input with 1 irrelevant param switching between 5 possible
+     * values, accuracy of completely new input is extremely high.
+     */
+    @Test
+    public void test4() {
+        Map<String, Object> outputs;
+
+        for (int i = 0; i < 50; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, false);
+            startAndReturnTaskOutputData("test item", "mary", i % 5, true);
+        }
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, false);
+        startAndReturnTaskOutputData("test item", "john", 5, false);
+        outputs = startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+
+        assertTrue((double) outputs.get("confidence") > 0.7);
+        assertEquals("true", outputs.get("approved"));
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series4Test.java
@@ -29,7 +29,7 @@ public class Series4Test extends NaiveBayesRecommendationServiceProcessTest {
      * values, accuracy of completely new input is extremely high.
      */
     @Test
-    public void test4() {
+    public void testHighPredictionConfidenceWithVaryingParameter() {
         Map<String, Object> outputs;
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.naivebayes;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series5Test extends NaiveBayesRecommendationServiceProcessTest {
+    @Test
+    public void test6() {
+        Map<String, Object> outputs;
+
+        for (int i = 0; i < 100; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, !(new Random().nextDouble() < 0.9));
+            startAndReturnTaskOutputData("test item", "mary", i % 5, new Random().nextDouble() < 0.9);
+            startAndReturnTaskOutputData("test item", "mary", i % 3, new Random().nextDouble() < 0.9);
+        }
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, false);
+        startAndReturnTaskOutputData("test item", "john", 5, false);
+        outputs = startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+
+        assertTrue((double) outputs.get("confidence") > 0.5);
+        assertEquals("true", outputs.get("approved"));
+
+    }
+
+}

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 public class Series5Test extends NaiveBayesRecommendationServiceProcessTest {
     @Test
     public void testConfidenceWithRandomOutcomes() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
 
         for (int i = 0; i < 100; i++) {
@@ -41,7 +42,6 @@ public class Series5Test extends NaiveBayesRecommendationServiceProcessTest {
         startAndReturnTaskOutputData("test item2", "krisv", 10, false);
         startAndReturnTaskOutputData("test item", "john", 5, false);
         outputs = startAndReturnTaskOutputData("test item2", "krisv", 10, true);
-
         assertTrue((double) outputs.get("confidence") > 0.5);
         assertEquals("true", outputs.get("approved"));
 

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series5Test.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 public class Series5Test extends NaiveBayesRecommendationServiceProcessTest {
     @Test
-    public void test6() {
+    public void testConfidenceWithRandomOutcomes() {
         Map<String, Object> outputs;
 
         for (int i = 0; i < 100; i++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
@@ -29,6 +29,7 @@ public class Series6Test extends NaiveBayesRecommendationServiceProcessTest {
     public void testAutoCompletion() {
         System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.85");
         Map<String, Object> outputs = new HashMap<>();
+        startAndReturnTaskOutputData("item6", "mary", 5, false);
         for (int i = 0; i < 200; i++) {
                 startAndReturnTaskOutputData("item6", "mary", 5, false);
             for (int j = 0 ; j < 6 ; j++) {

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
@@ -27,11 +27,13 @@ import static org.junit.Assert.assertTrue;
 public class Series6Test extends NaiveBayesRecommendationServiceProcessTest {
     @Test
     public void testAutoCompletion() {
-        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.95");
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.85");
         Map<String, Object> outputs = new HashMap<>();
-        startAndReturnTaskOutputData("item6", "mary", 5, false);
         for (int i = 0; i < 200; i++) {
-            outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
+                startAndReturnTaskOutputData("item6", "mary", 5, false);
+            for (int j = 0 ; j < 6 ; j++) {
+                outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
+            }
         }
         assertTrue(outputs.isEmpty());
     }

--- a/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
+++ b/jbpm-recommendation-smile-naivebayes/src/test/java/org/jbpm/prediction/naivebayes/Series6Test.java
@@ -18,28 +18,22 @@ package org.jbpm.prediction.naivebayes;
 
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class Series3Test extends NaiveBayesRecommendationServiceProcessTest {
-    /**
-     * This test shows how the accuracy goes extremely quickly to 1.0 (100.0%) if you give it the same result initially
-     * it does not even respond to different inputs
-     */
+public class Series6Test extends NaiveBayesRecommendationServiceProcessTest {
     @Test
-    public void testOutcomeWithPreviouslyUnseenInputData() {
-        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
-        Map<String, Object> outputs;
-
-        for (int i = 0; i < 10; i++) {
-            startAndReturnTaskOutputData("test item", "john", i % 5, false);
+    public void testAutoCompletion() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.95");
+        Map<String, Object> outputs = new HashMap<>();
+        startAndReturnTaskOutputData("item6", "mary", 5, false);
+        for (int i = 0; i < 200; i++) {
+            outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
         }
-        startAndReturnTaskOutputData("test item2", "mary", 10, true);
-        outputs = startAndReturnTaskOutputData("test item2", "mary", 10, true);
-
-        assertEquals("true", outputs.get("approved"));
+        assertTrue(outputs.isEmpty());
     }
 
 }

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/BPMN2-UserTask.bpmn2
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/BPMN2-UserTask.bpmn2
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_ZXxk4PPIEei3vdSeFAookw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_itemItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_actorItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_levelItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_approvedItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputXItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputXItem" structureRef="Boolean"/>
+  <bpmn2:process id="UserTask" drools:packageName="com.myspace.project" drools:version="1.0" name="process" isExecutable="true">
+    <bpmn2:property id="actor" itemSubjectRef="_actorItem"/>
+    <bpmn2:property id="item" itemSubjectRef="_itemItem"/>
+    <bpmn2:property id="level" itemSubjectRef="_levelItem"/>
+    <bpmn2:property id="approved" itemSubjectRef="_approvedItem"/>
+    <bpmn2:sequenceFlow id="_7990B36D-F7C5-48D3-AD5B-69DC694E53A5" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B" targetRef="_3B67882C-C399-4963-907A-4A1EBFB7BE50"/>
+    <bpmn2:startEvent id="_F1177242-F8C7-4623-98A6-1CE014F68C0E" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_93FF521A-176E-4C9E-90E0-BC0B7411DC30</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Task">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_93FF521A-176E-4C9E-90E0-BC0B7411DC30</bpmn2:incoming>
+      <bpmn2:outgoing>_7990B36D-F7C5-48D3-AD5B-69DC694E53A5</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_ZXxk4fPIEei3vdSeFAookw">
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX" drools:dtype="String" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX" drools:dtype="String" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputXItem" name="item"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX" drools:dtype="Integer" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputXItem" name="level"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX" drools:dtype="Object" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputXItem" name="approved"/>
+        <bpmn2:inputSet id="_ZXxk4vPIEei3vdSeFAookw">
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_ZXxk4_PIEei3vdSeFAookw">
+          <bpmn2:dataOutputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_ZXxk5PPIEei3vdSeFAookw">
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_ZXxk5fPIEei3vdSeFAookw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_ZXxk5vPIEei3vdSeFAookw"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_ZXyL8PPIEei3vdSeFAookw">_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8fPIEei3vdSeFAookw">
+        <bpmn2:sourceRef>item</bpmn2:sourceRef>
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8vPIEei3vdSeFAookw">
+        <bpmn2:sourceRef>level</bpmn2:sourceRef>
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8_PIEei3vdSeFAookw">
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_ZXyL9PPIEei3vdSeFAookw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_ZXyL9fPIEei3vdSeFAookw">false</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_ZXyL9vPIEei3vdSeFAookw">_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_ZXyL9_PIEei3vdSeFAookw">
+        <bpmn2:sourceRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>approved</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:potentialOwner id="_ZXyL-PPIEei3vdSeFAookw">
+        <bpmn2:resourceAssignmentExpression id="_ZXyL-fPIEei3vdSeFAookw">
+          <bpmn2:formalExpression id="_ZXyL-vPIEei3vdSeFAookw">#{actor}</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="_3B67882C-C399-4963-907A-4A1EBFB7BE50" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_7990B36D-F7C5-48D3-AD5B-69DC694E53A5</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_93FF521A-176E-4C9E-90E0-BC0B7411DC30" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F1177242-F8C7-4623-98A6-1CE014F68C0E" targetRef="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_ZXyL-_PIEei3vdSeFAookw">
+    <bpmndi:BPMNPlane id="_ZXyL_PPIEei3vdSeFAookw" bpmnElement="UserTask">
+      <bpmndi:BPMNShape id="_ZXyL_fPIEei3vdSeFAookw" bpmnElement="_F1177242-F8C7-4623-98A6-1CE014F68C0E">
+        <dc:Bounds height="30.0" width="30.0" x="105.0" y="113.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ZXyL_vPIEei3vdSeFAookw" bpmnElement="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B">
+        <dc:Bounds height="102.0" width="154.0" x="225.0" y="77.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ZXyL__PIEei3vdSeFAookw" bpmnElement="_3B67882C-C399-4963-907A-4A1EBFB7BE50">
+        <dc:Bounds height="28.0" width="28.0" x="459.0" y="114.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_ZXyMAPPIEei3vdSeFAookw" bpmnElement="_7990B36D-F7C5-48D3-AD5B-69DC694E53A5" sourceElement="_ZXyL_vPIEei3vdSeFAookw" targetElement="_ZXyL__PIEei3vdSeFAookw">
+        <di:waypoint xsi:type="dc:Point" x="302.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="473.0" y="128.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ZXyMAfPIEei3vdSeFAookw" bpmnElement="_93FF521A-176E-4C9E-90E0-BC0B7411DC30" sourceElement="_ZXyL_fPIEei3vdSeFAookw" targetElement="_ZXyL_vPIEei3vdSeFAookw">
+        <di:waypoint xsi:type="dc:Point" x="120.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="302.0" y="128.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+  <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+    <jta-data-source>jdbc/testDS1</jta-data-source>       
+    <mapping-file>META-INF/Taskorm.xml</mapping-file>
+    <mapping-file>META-INF/JBPMorm.xml</mapping-file>
+    <mapping-file>META-INF/Servicesorm.xml</mapping-file>
+    <mapping-file>META-INF/TaskAuditorm.xml</mapping-file>
+
+    <class>org.jbpm.services.task.impl.model.AttachmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.ContentImpl</class>
+    <class>org.jbpm.services.task.impl.model.BooleanExpressionImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.DelegationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EscalationImpl</class>
+    <class>org.jbpm.services.task.impl.model.GroupImpl</class>
+    <class>org.jbpm.services.task.impl.model.I18NTextImpl</class>
+    <class>org.jbpm.services.task.impl.model.NotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationHeaderImpl</class>
+    <class>org.jbpm.services.task.impl.model.PeopleAssignmentsImpl</class>
+    <class>org.jbpm.services.task.impl.model.ReassignmentImpl</class>
+    
+    <class>org.jbpm.services.task.impl.model.TaskImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
+    <class>org.jbpm.services.task.impl.model.UserImpl</class>
+    
+    
+
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+    <!-- manager -->
+    <class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+    
+    <!-- bam -->
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    <class>org.jbpm.process.audit.NodeInstanceLog</class>
+    <class>org.jbpm.process.audit.VariableInstanceLog</class>  
+    
+    <!--BAM for task service -->
+    <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>
+    
+    <!-- Event Classes -->
+    <class>org.jbpm.services.task.audit.impl.model.TaskEventImpl</class>
+    
+    <!-- Task Audit Classes --> 
+    <class>org.jbpm.services.task.audit.impl.model.AuditTaskImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.TaskVariableImpl</class>
+    
+    <!-- deployment store -->
+    <class>org.jbpm.kie.services.impl.store.DeploymentStoreEntry</class>
+    
+    <!--  query service storage -->
+    <class>org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity</class>
+    
+    <!-- error handling -->
+    <class>org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo</class>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+      <property name="hibernate.connection.autocommit" value="false" />
+
+      <property name="hibernate.max_fetch_depth" value="3" />
+      <property name="hibernate.hbm2ddl.auto" value="create" />
+      <property name="hibernate.show_sql" value="false" />
+
+    
+      <property name="hibernate.transaction.manager_lookup_class" value="org.hibernate.transaction.BTMTransactionManagerLookup" />
+
+      <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
+      <property name="hibernate.id.new_generator_mappings" value="false" />
+      <property name="hibernate.connection.release_mode" value="after_transaction"/>
+    </properties>
+  </persistence-unit>
+
+
+
+</persistence>

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/inputs.properties
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/inputs.properties
@@ -1,0 +1,3 @@
+item=NOMINAL
+ActorId=NOMINAL
+level=NOMINAL

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/jndi.properties
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/jndi.properties
@@ -1,0 +1,4 @@
+java.naming.factory.initial=org.jbpm.test.util.CloseSafeMemoryContextFactory
+org.osjava.sj.root=target/test-classes/config
+org.osjava.jndi.delimiter=/
+org.osjava.sj.jndi.shared=true

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/jndi.properties
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/jndi.properties
@@ -1,4 +1,0 @@
-java.naming.factory.initial=org.jbpm.test.util.CloseSafeMemoryContextFactory
-org.osjava.sj.root=target/test-classes/config
-org.osjava.jndi.delimiter=/
-org.osjava.sj.jndi.shared=true

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/logback-test.xml
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t|%C] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.arjuna" level="error"/>
+  <logger name="org.hibernate" level="warn"/>
+  <logger name="org.hibernate.tool.hbm2ddl.SchemaExport" level="off"/>
+  
+  <logger name="org.jbpm.services.task.wih" level="warn"/>
+  <logger name="org.jbpm.services.task.impl" level="info"/>
+  
+  <logger name="org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl" level="error" />
+
+  <logger name="org.jbpm.prediction.naivebayes.SmileNaiveBayes" level="debug"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>

--- a/jbpm-recommendation-smile-naivebayes/src/test/resources/output.properties
+++ b/jbpm-recommendation-smile-naivebayes/src/test/resources/output.properties
@@ -1,0 +1,3 @@
+name=approved
+type=NOMINAL
+confidence_threshold=1.0

--- a/jbpm-recommendation-smile-random-forest/README.md
+++ b/jbpm-recommendation-smile-random-forest/README.md
@@ -1,0 +1,30 @@
+# jBPM SMILE Random forest prediction service
+
+## Description
+
+This module contains an example implementation of a prediction service
+backend using a SMILE random forest-based example.
+
+The prediction service allows to set a model's predictions as the
+Human Task output. If the prediction's `confidence` is higher than the
+`confidenceThreshold` then the Human Task is automatically completed.
+
+ The example Human Task has three inputs (`actor`, `level`, `item`) and one output (`approved`).
+ 
+ The service can be configured using the following property files:
+ 
+ * `inputs.properties`, a key/value list of attribute name/attribute type (e.g. `item=NOMINAL` means `item` is a nominal attribute)
+ * `output.properties` contains the output attribute name and type, the confidence threshold and the number of trees to be used
+
+ 
+ ## Installation
+ 
+ To install the service example simply build the JAR using
+ 
+ ```
+$ mvn clean install
+```
+
+and place it in the jBPM server's classpath.
+
+The example Human Task located in `test/resources/BPMN2-UserTask.bpmn2` can be imported into jBPM to run the example. 

--- a/jbpm-recommendation-smile-random-forest/pom.xml
+++ b/jbpm-recommendation-smile-random-forest/pom.xml
@@ -1,0 +1,94 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm</artifactId>
+        <version>7.27.0.Final</version>
+    </parent>
+
+    <artifactId>jbpm-recommendation-smile-random-forest</artifactId>
+
+    <name>jBPM :: Prediction :: Random Forest based prediction service</name>
+    <description>Random Forest based prediction service</description>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.haifengl</groupId>
+          <artifactId>smile-core</artifactId>
+          <version>1.5.2</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+  
+    <dependencies>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-internal</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-test-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-test-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-kie-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- javax.el required by hibernate-validator -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.el</groupId>
+            <artifactId>jboss-el-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.jta</groupId>
+            <artifactId>narayana-jta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.haifengl</groupId>
+            <artifactId>smile-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jbpm-recommendation-smile-random-forest/pom.xml
+++ b/jbpm-recommendation-smile-random-forest/pom.xml
@@ -13,12 +13,17 @@
     <name>jBPM :: Prediction :: Random Forest based prediction service</name>
     <description>Random Forest based prediction service</description>
 
+    <properties>
+        <smile.version>1.5.2</smile.version>
+    </properties>
+
+
     <dependencyManagement>
       <dependencies>
         <dependency>
           <groupId>com.github.haifengl</groupId>
           <artifactId>smile-core</artifactId>
-          <version>1.5.2</version>
+          <version>${smile.version}</version>
         </dependency>
       </dependencies>
     </dependencyManagement>

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AbstractPredictionEngine.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AbstractPredictionEngine.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import java.util.Map;
+
+abstract public class AbstractPredictionEngine {
+
+    protected Map<String, AttributeType> inputFeatures;
+    protected String outcomeFeatureName;
+    protected AttributeType outcomeFeatureType;
+    protected double confidenceThreshold;
+
+    public AbstractPredictionEngine(Map<String, AttributeType> inputFeatures, String outputFeatureName, AttributeType outputFeatureType, double confidenceThreshold) {
+        this.inputFeatures = inputFeatures;
+        this.outcomeFeatureName = outputFeatureName;
+        this.outcomeFeatureType = outputFeatureType;
+        this.confidenceThreshold = confidenceThreshold;
+    }
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AbstractPredictionEngine.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AbstractPredictionEngine.java
@@ -18,7 +18,7 @@ package org.jbpm.prediction.randomforest;
 
 import java.util.Map;
 
-abstract public class AbstractPredictionEngine {
+public abstract class AbstractPredictionEngine {
 
     protected Map<String, AttributeType> inputFeatures;
     protected String outcomeFeatureName;

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AttributeType.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/AttributeType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+public enum AttributeType {
+    STRING,
+    NOMINAL,
+    NUMERIC
+}

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/RandomForestConfiguration.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/RandomForestConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Encapsulates the model's output information.
+ */
+public class RandomForestConfiguration {
+
+    private String outcomeName;
+    private AttributeType outcomeType;
+    private double confidenceThreshold;
+    private int numTrees;
+    private Map<String, AttributeType> inputFeatures = new HashMap<>();
+
+    public int getNumTrees() {
+        return numTrees;
+    }
+
+    public void setNumTrees(int numTrees) {
+        this.numTrees = numTrees;
+    }
+
+    /**
+     * Returns the name of the output attribute
+     *
+     * @return The name of the output attribute
+     */
+    public String getOutcomeName() {
+        return outcomeName;
+    }
+
+    public void setOutcomeName(String outcomeName) {
+        this.outcomeName = outcomeName;
+    }
+
+    /**
+     * Returns the type of the output attribute {@link AttributeType}
+     *
+     * @return The type of the output attribute
+     */
+    public AttributeType getOutcomeType() {
+        return outcomeType;
+    }
+
+    public void setOutcomeType(AttributeType outcomeType) {
+        this.outcomeType = outcomeType;
+    }
+
+    /**
+     * Returns the confidence threshold to use for automatic task completion
+     *
+     * @return The confidence threshold, between 0.0 and 1.0
+     */
+    public double getConfidenceThreshold() {
+        return confidenceThreshold;
+    }
+
+    public void setConfidenceThreshold(double confidenceThreshold) {
+        this.confidenceThreshold = confidenceThreshold;
+    }
+
+    public Map<String, AttributeType> getInputFeatures() {
+        return inputFeatures;
+    }
+
+    public void setInputFeatures(Map<String, AttributeType> inputFeatures) {
+        this.inputFeatures = inputFeatures;
+    }
+}

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/RandomForestRegistry.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/RandomForestRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.kie.internal.task.api.prediction.PredictionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+
+public class RandomForestRegistry {
+    private static final ServiceLoader<PredictionService> foundServices = ServiceLoader.load(PredictionService.class, RandomForestRegistry.class.getClassLoader());
+    private String selectedService = System.getProperty("org.jbpm.prediction.randomforest", SmileRandomForest.IDENTIFIER);
+    private Map<String, PredictionService> predictionServices = new HashMap<>();
+
+    private RandomForestRegistry() {
+
+        foundServices
+                .forEach(strategy -> predictionServices.put(strategy.getIdentifier(), strategy));
+    }
+
+    public static RandomForestRegistry get() {
+        return Holder.INSTANCE;
+    }
+
+    public PredictionService getService() {
+        PredictionService predictionService = predictionServices.get(selectedService);
+        if (predictionService == null) {
+            throw new IllegalArgumentException("No prediction service was found with id " + selectedService);
+        }
+
+        return predictionService;
+    }
+
+    public synchronized void addStrategy(SmileRandomForest predictionService) {
+        this.predictionServices.put(predictionService.getIdentifier(), predictionService);
+
+    }
+
+    private static class Holder {
+        static final RandomForestRegistry INSTANCE = new RandomForestRegistry();
+    }
+}

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/SmileRandomForest.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/SmileRandomForest.java
@@ -222,6 +222,19 @@ public class SmileRandomForest extends AbstractPredictionEngine implements Predi
      */
     @Override
     public PredictionOutcome predict(Task task, Map<String, Object> inputData) {
+
+        // Allow confidence threshold to be overriden by a Java property
+        final String confidenceThreshold = System.getProperty("org.jbpm.task.prediction.service.confidence_threshold");
+
+        // Check if the confidence threshold was set at runtime, otherwise keep using as defined in output.properties
+        if (confidenceThreshold!=null) {
+            try {
+                this.confidenceThreshold = Double.parseDouble(confidenceThreshold);
+            } catch (NumberFormatException e) {
+                logger.error("Invalid confidence threshold set in org.jbpm.task.prediction.service.confidence_threshold");
+            }
+        }
+
         Map<String, Object> outcomes = new HashMap<>();
         if (outcomeSet.size() >= 2) {
             model = new RandomForest(dataset, this.numberTrees);

--- a/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/SmileRandomForest.java
+++ b/jbpm-recommendation-smile-random-forest/src/main/java/org/jbpm/prediction/randomforest/SmileRandomForest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.kie.api.task.model.Task;
+import org.kie.internal.task.api.prediction.PredictionOutcome;
+import org.kie.internal.task.api.prediction.PredictionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import smile.classification.RandomForest;
+import smile.data.*;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.*;
+
+public class SmileRandomForest extends AbstractPredictionEngine implements PredictionService {
+
+    public static final String IDENTIFIER = "SMILERandomForest";
+    private static final Logger logger = LoggerFactory.getLogger(SmileRandomForest.class);
+    private final AttributeDataset dataset;
+    private final Map<String, Attribute> smileAttributes;
+    private final Attribute outcomeAttribute;
+    private final int numAttributes;
+    private final int numberTrees;
+    protected List<String> attributeNames = new ArrayList<>();
+    private RandomForest model = null;
+    private Set<String> outcomeSet = new HashSet<>();
+
+    public SmileRandomForest() {
+        this(readConfigurationFromFile());
+    }
+
+    public SmileRandomForest(RandomForestConfiguration configuration) {
+        this(configuration.getInputFeatures(),
+                configuration.getOutcomeName(),
+                configuration.getOutcomeType(),
+                configuration.getConfidenceThreshold(),
+                configuration.getNumTrees());
+    }
+
+    public SmileRandomForest(Map<String, AttributeType> inputFeatures,
+                             String outputFeatureName,
+                             AttributeType outputFeatureType,
+                             double confidenceThreshold,
+                             int numberTrees) {
+        super(inputFeatures, outputFeatureName, outputFeatureType, confidenceThreshold);
+        this.numberTrees = numberTrees;
+        smileAttributes = new HashMap<>();
+        for (Map.Entry<String, AttributeType> inputFeature : inputFeatures.entrySet()) {
+            final String name = inputFeature.getKey();
+            final AttributeType type = inputFeature.getValue();
+            smileAttributes.put(name, createAttribute(name, type));
+            attributeNames.add(name);
+        }
+        numAttributes = smileAttributes.size();
+        outcomeAttribute = createAttribute(outputFeatureName, outputFeatureType);
+        dataset = new AttributeDataset("dataset", smileAttributes.values().toArray(new Attribute[numAttributes]), outcomeAttribute);
+    }
+
+    /**
+     * Reads the random forest configuration from properties files.
+     * "inputs.properties" should contain the input attribute names as keys and attribute types as values.
+     *
+     * @return A map of input attributes with the attribute name as key and attribute type as value.
+     */
+    private static RandomForestConfiguration readConfigurationFromFile() {
+
+        final RandomForestConfiguration configuration = new RandomForestConfiguration();
+
+        InputStream inputStream = null;
+        final Map<String, AttributeType> inputFeatures = new HashMap<>();
+        try {
+            Properties prop = new Properties();
+
+            inputStream = SmileRandomForest.class.getClassLoader().getResourceAsStream("inputs.properties");
+
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("Could not find the property file 'inputs.properties' in the classpath.");
+            }
+
+            for (Object propertyName : prop.keySet()) {
+                inputFeatures.put((String) propertyName, AttributeType.valueOf(prop.getProperty((String) propertyName)));
+            }
+
+        } catch (Exception e) {
+            logger.error("Exception: " + e);
+        }
+        configuration.setInputFeatures(inputFeatures);
+
+        try {
+            Properties prop = new Properties();
+
+            inputStream = SmileRandomForest.class.getClassLoader().getResourceAsStream("output.properties");
+
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("Could not find the property file 'output.properties' in the classpath.");
+            }
+
+            configuration.setOutcomeName(prop.getProperty("name"));
+            configuration.setOutcomeType(AttributeType.valueOf(prop.getProperty("type")));
+            configuration.setConfidenceThreshold(Double.parseDouble(prop.getProperty("confidence_threshold")));
+            configuration.setNumTrees(Integer.parseInt(prop.getProperty("num_trees")));
+        } catch (Exception e) {
+            logger.error("Exception: " + e);
+        }
+        return configuration;
+    }
+
+    private static Attribute createAttribute(String name, AttributeType type) {
+        if (type == AttributeType.NOMINAL) {
+            return new NominalAttribute(name);
+        } else if (type == AttributeType.NUMERIC) {
+            return new NumericAttribute(name);
+        } else {
+            return new StringAttribute(name);
+        }
+    }
+
+    /**
+     * Add the data provided as a map to a Smile {@link smile.data.Dataset}.
+     *
+     * @param data    A map containing the input attribute names as keys and the attribute values as values.
+     * @param outcome The value of the outcome (output data).
+     */
+    public void addData(Map<String, Object> data, Object outcome) {
+        final double[] features = new double[numAttributes];
+        int i = 0;
+        for (String attrName : smileAttributes.keySet()) {
+            try {
+                features[i] = smileAttributes.get(attrName).valueOf(data.get(attrName).toString());
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+            i++;
+        }
+        try {
+            final String outcomeStr = outcome.toString();
+            outcomeSet.add(outcomeStr);
+            dataset.add(features, outcomeAttribute.valueOf(outcomeStr));
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Build a set of features compatible with Smile's datasets from the map of input data
+     *
+     * @param data A map containing the input attribute names as keys and the attribute values as values.
+     * @return A feature vector as a array of doubles.
+     */
+    protected double[] buildFeatures(Map<String, Object> data) {
+        final double[] features = new double[numAttributes];
+        for (int i = 0; i < numAttributes; i++) {
+            final String attrName = attributeNames.get(i);
+            try {
+                features[i] = smileAttributes.get(attrName).valueOf(data.get(attrName).toString());
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return features;
+    }
+
+    /**
+     * Returns the service's identifier
+     *
+     * @return The service identifier
+     */
+    @Override
+    public String getIdentifier() {
+        return IDENTIFIER;
+    }
+
+    /**
+     * Returns a model prediction given the input data
+     *
+     * @param task      Human task data
+     * @param inputData A map containing the input attribute names as keys and the attribute values as values.
+     * @return A {@link PredictionOutcome} containing the model's prediction for the input data.
+     */
+    @Override
+    public PredictionOutcome predict(Task task, Map<String, Object> inputData) {
+        Map<String, Object> outcomes = new HashMap<>();
+        if (outcomeSet.size() >= 2) {
+            model = new RandomForest(dataset, this.numberTrees);
+            final double[] features = buildFeatures(inputData);
+            final double[] posteriori = new double[outcomeSet.size()];
+            double prediction = model.predict(features, posteriori);
+
+            String predictionStr = dataset.responseAttribute().toString(prediction);
+            outcomes.put(outcomeAttribute.getName(), predictionStr);
+            final double confidence = posteriori[(int) prediction];
+            outcomes.put("confidence", confidence);
+
+            logger.debug(inputData + ", prediction = " + predictionStr + ", confidence = " + confidence);
+
+            return new PredictionOutcome(confidence, this.confidenceThreshold, outcomes);
+        } else {
+            return new PredictionOutcome(0.0, this.confidenceThreshold, outcomes);
+        }
+    }
+
+    /**
+     * Train the random forest model using data from the human task.
+     *
+     * @param task       Human task data
+     * @param inputData  A map containing the input attribute names as keys and the attribute values as values.
+     * @param outputData A map containing the output attribute names as keys and the attribute values as values.
+     */
+    @Override
+    public void train(Task task, Map<String, Object> inputData, Map<String, Object> outputData) {
+        addData(inputData, outputData.get(outcomeAttribute.getName()));
+    }
+}

--- a/jbpm-recommendation-smile-random-forest/src/main/resources/META-INF/services/org.kie.internal.task.api.prediction.PredictionService
+++ b/jbpm-recommendation-smile-random-forest/src/main/resources/META-INF/services/org.kie.internal.task.api.prediction.PredictionService
@@ -1,0 +1,1 @@
+org.jbpm.prediction.randomforest.SmileRandomForest

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/EqualProbabilityTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/EqualProbabilityTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class EqualProbabilityTest extends RandomForestPredictionServiceProcessTest {
+
+    /**
+     * Insert an equal number of true and false samples, making
+     * sure the total number of samples is larger than the dataset
+     * size threshold. Since the dataset size
+     * threshold will have been met and the probability of true
+     * and false will be nearly equal, we expect confidence to be
+     * lower than 0.55 (55%).
+     */
+    @Test
+    public void testEqualProbabilityRandomForestPredictionService() {
+        Map<String, Object> outputs = new HashMap<>();
+
+        for (int i = 0; i < 100; i++) {
+            startAndReturnTaskOutputData("test item", "john", 5, false);
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
+        }
+
+        final double confidence = (double) outputs.get("confidence");
+        assertTrue(confidence < 0.6 && confidence > 0.4);
+    }
+
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/EqualProbabilityTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/EqualProbabilityTest.java
@@ -35,6 +35,7 @@ public class EqualProbabilityTest extends RandomForestPredictionServiceProcessTe
      */
     @Test
     public void testEqualProbabilityRandomForestPredictionService() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 100; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RandomForestPredictionServiceProcessTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RandomForestPredictionServiceProcessTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.test.services.AbstractKieServicesTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.kie.api.task.model.TaskSummary;
+import org.kie.internal.query.QueryFilter;
+
+import java.util.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class RandomForestPredictionServiceProcessTest extends AbstractKieServicesTest {
+
+    private List<Long> instances = new ArrayList<>();
+
+    protected static void assertBetween(double value, double min, double max) {
+        assertTrue(value > min && value < max);
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        System.setProperty("org.jbpm.task.prediction.service", SmileRandomForest.IDENTIFIER);
+    }
+
+    @AfterClass
+    public static void cleanOnce() {
+        System.clearProperty("org.jbpm.task.prediction.service");
+    }
+
+    @Override
+    protected List<String> getProcessDefinitionFiles() {
+        List<String> processes = new ArrayList<>();
+        processes.add("BPMN2-UserTask.bpmn2");
+        return processes;
+    }
+
+    @Override
+    public DeploymentUnit prepareDeploymentUnit() throws Exception {
+        // specify GROUP_ID, ARTIFACT_ID, VERSION of your kjar
+        return createAndDeployUnit("org.jbpm.test.prediction", "random-forest-test", "1.0.0");
+    }
+
+    protected Map<String, Object> startAndReturnTaskOutputData(String item, String userId, Integer level, Boolean approved) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("item", item);
+        parameters.put("level", level);
+        parameters.put("actor", userId);
+        long processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "UserTask", parameters);
+        instances.add(processInstanceId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksByStatusByProcessInstanceId(processInstanceId, null, new QueryFilter());
+        assertNotNull(tasks);
+
+        if (!tasks.isEmpty()) {
+
+            Long taskId = tasks.get(0).getId();
+
+            Map<String, Object> outputs = userTaskService.getTaskOutputContentByTaskId(taskId);
+            assertNotNull(outputs);
+
+            userTaskService.completeAutoProgress(taskId, userId, Collections.singletonMap("approved", approved));
+
+            return outputs;
+        }
+
+        return null;
+    }
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RandomForestPredictionServiceProcessTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RandomForestPredictionServiceProcessTest.java
@@ -82,6 +82,6 @@ public abstract class RandomForestPredictionServiceProcessTest extends AbstractK
             return outputs;
         }
 
-        return null;
+        return new HashMap<>();
     }
 }

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RepeatedRandomForestTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RepeatedRandomForestTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class RepeatedRandomForestTest extends RandomForestPredictionServiceProcessTest {
+    /**
+     * For this test insert a quantity of true training samples
+     * to verify the random forest class/process is functional.
+     * Expect confidence > 90.0 and "approved" to be true.
+     */
+    @Test
+    public void testRepeatedRandomForestPredictionService() {
+        Map<String, Object> outputs;
+        outputs = startAndReturnTaskOutputData("test item", "john", 5, false);
+        for (int i = 0; i < 40; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
+        }
+        assertEquals("true", outputs.get("approved"));
+    }
+
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RepeatedRandomForestTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/RepeatedRandomForestTest.java
@@ -30,6 +30,7 @@ public class RepeatedRandomForestTest extends RandomForestPredictionServiceProce
      */
     @Test
     public void testRepeatedRandomForestPredictionService() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
         outputs = startAndReturnTaskOutputData("test item", "john", 5, false);
         for (int i = 0; i < 40; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Series1Test extends RandomForestPredictionServiceProcessTest {
+
+    /**
+     * This test shows how after testing with a mixed set (3x false, 17x true) how prediction (and probability)
+     * evolve when you then keep sending as "false" value to the outcome.
+     */
+    @Test
+    public void test1() {
+        Map<String, Object> outputs = new HashMap<>();
+
+        for (int i = 0; i < 17; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
+        }
+        for (int i = 0; i < 40; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, false);
+        }
+        assertTrue((double) outputs.get("confidence") > 0.5);
+        assertEquals("false", outputs.get("approved"));
+
+    }
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
@@ -27,17 +27,17 @@ import static org.junit.Assert.assertTrue;
 public class Series1Test extends RandomForestPredictionServiceProcessTest {
 
     /**
-     * This test shows how after testing with a mixed set (3x false, 17x true) how prediction (and probability)
+     * This test shows how after testing with a mixed set (60x false, 17x true) how prediction (and probability)
      * evolve when you then keep sending as "false" value to the outcome.
      */
     @Test
-    public void test1() {
+    public void testChangingConfidenceWithInputDataDrift() {
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 17; i++) {
             outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
         }
-        for (int i = 0; i < 40; i++) {
+        for (int i = 0; i < 60; i++) {
             outputs = startAndReturnTaskOutputData("test item", "john", 5, false);
         }
         assertTrue((double) outputs.get("confidence") > 0.5);

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series1Test.java
@@ -32,6 +32,7 @@ public class Series1Test extends RandomForestPredictionServiceProcessTest {
      */
     @Test
     public void testChangingConfidenceWithInputDataDrift() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 17; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
@@ -31,7 +31,7 @@ public class Series3Test extends RandomForestPredictionServiceProcessTest {
      * values, it takes a while longer to get to high accuracy
      */
     @Test
-    public void test3() {
+    public void testPredictionWithHighVaryingParameter() {
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Series3Test extends RandomForestPredictionServiceProcessTest {
+
+
+    /**
+     * This test shows how after passing min count of 2 input with 1 irrelevant param switching between 5 possible
+     * values, it takes a while longer to get to high accuracy
+     */
+    @Test
+    public void test3() {
+        Map<String, Object> outputs = new HashMap<>();
+
+        for (int i = 0; i < 50; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", i % 5, false);
+            startAndReturnTaskOutputData("test item", "mary", i % 5, true);
+        }
+        assertBetween((double) outputs.get("confidence"), 0.5, 1.0);
+        assertEquals("false", outputs.get("approved"));
+    }
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series3Test.java
@@ -32,6 +32,7 @@ public class Series3Test extends RandomForestPredictionServiceProcessTest {
      */
     @Test
     public void testPredictionWithHighVaryingParameter() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs = new HashMap<>();
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
@@ -31,6 +31,7 @@ public class Series4Test extends RandomForestPredictionServiceProcessTest {
      */
     @Test
     public void testHighPredictionConfidenceWithVaryingParameter() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
@@ -30,7 +30,7 @@ public class Series4Test extends RandomForestPredictionServiceProcessTest {
      * values, accuracy of completely new input is extremely high.
      */
     @Test
-    public void test4() {
+    public void testHighPredictionConfidenceWithVaryingParameter() {
         Map<String, Object> outputs;
 
         for (int i = 0; i < 50; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series4Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Series4Test extends RandomForestPredictionServiceProcessTest {
+
+
+    /**
+     * This test shows how after passing min count of 2 input with 1 irrelevant param switching between 5 possible
+     * values, accuracy of completely new input is extremely high.
+     */
+    @Test
+    public void test4() {
+        Map<String, Object> outputs;
+
+        for (int i = 0; i < 50; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, false);
+            startAndReturnTaskOutputData("test item", "mary", i % 5, true);
+        }
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, false);
+        startAndReturnTaskOutputData("test item", "john", 5, false);
+        outputs = startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+
+        assertBetween((double) outputs.get("confidence"), 0.3, 0.7);
+    }
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
@@ -25,7 +25,7 @@ public class Series5Test extends RandomForestPredictionServiceProcessTest {
 
 
     @Test
-    public void test6() {
+    public void testConfidenceWithRandomOutcomes() {
         Map<String, Object> outputs;
 
         for (int i = 0; i < 100; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Random;
+
+public class Series5Test extends RandomForestPredictionServiceProcessTest {
+
+
+    @Test
+    public void test6() {
+        Map<String, Object> outputs;
+
+        for (int i = 0; i < 100; i++) {
+            startAndReturnTaskOutputData("test item", "john", i % 5, !(new Random().nextDouble() < 0.9));
+            startAndReturnTaskOutputData("test item", "mary", i % 5, new Random().nextDouble() < 0.9);
+            startAndReturnTaskOutputData("test item", "mary", i % 3, new Random().nextDouble() < 0.9);
+        }
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 11, false);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        startAndReturnTaskOutputData("test item2", "krisv", 10, false);
+        startAndReturnTaskOutputData("test item", "john", 5, false);
+        outputs = startAndReturnTaskOutputData("test item2", "krisv", 10, true);
+        assertBetween((double) outputs.get("confidence"), 0.4, 0.6);
+    }
+
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series5Test.java
@@ -26,6 +26,7 @@ public class Series5Test extends RandomForestPredictionServiceProcessTest {
 
     @Test
     public void testConfidenceWithRandomOutcomes() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
 
         for (int i = 0; i < 100; i++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
@@ -30,6 +30,7 @@ public class Series6Test extends RandomForestPredictionServiceProcessTest {
     public void testAutoCompletion() {
         System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.85");
         Map<String, Object> outputs = new HashMap<>();
+        startAndReturnTaskOutputData("item6", "mary", 5, false);
         for (int i = 0; i < 200; i++) {
             outputs = startAndReturnTaskOutputData("item6", "mary", 5, false);
             for (int j = 0 ; j < 6 ; j++) {

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jbpm.prediction.naivebayes;
+package org.jbpm.prediction.randomforest;
 
 import org.junit.Test;
 
@@ -24,23 +24,18 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class Series2Test extends NaiveBayesRecommendationServiceProcessTest {
-    /**
-     * This test shows how after passing min count of 2 input with 1 irrelevant param switching between 5 possible
-     * values, it takes a while longer to get to high accuracy
-     */
+public class Series6Test extends RandomForestPredictionServiceProcessTest {
+
     @Test
-    public void testPredictionWithHighVaryingParameter() {
-        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
+    public void testAutoCompletion() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.95");
         Map<String, Object> outputs = new HashMap<>();
-
-        for (int i = 0; i < 50; i++) {
-            startAndReturnTaskOutputData("test item", "john", i % 5, false);
-            outputs = startAndReturnTaskOutputData("test item", "mary", i % 5, true);
+        startAndReturnTaskOutputData("item6", "mary", 5, false);
+        for (int i = 0; i < 200; i++) {
+            outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
         }
-        assertTrue((double) outputs.get("confidence") > 0.7);
-        assertEquals("true", outputs.get("approved"));
-
+        assertTrue(outputs.isEmpty());
     }
+
 
 }

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/Series6Test.java
@@ -28,11 +28,13 @@ public class Series6Test extends RandomForestPredictionServiceProcessTest {
 
     @Test
     public void testAutoCompletion() {
-        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.95");
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "0.85");
         Map<String, Object> outputs = new HashMap<>();
-        startAndReturnTaskOutputData("item6", "mary", 5, false);
         for (int i = 0; i < 200; i++) {
-            outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
+            outputs = startAndReturnTaskOutputData("item6", "mary", 5, false);
+            for (int j = 0 ; j < 6 ; j++) {
+                outputs = startAndReturnTaskOutputData("item6", "mary", 5, true);
+            }
         }
         assertTrue(outputs.isEmpty());
     }

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/UnequalProbabilityTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/UnequalProbabilityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.prediction.randomforest;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnequalProbabilityTest extends RandomForestPredictionServiceProcessTest {
+
+    /**
+     * Insert a disproportionate partitioning of true and false samples
+     * of a sample set larger than the dataset size threshold. In this
+     * case true will have higher probability and as such we expect
+     * confidence to be high.
+     */
+    @Test
+    public void testUnequalProbabilityRandomForestPredictionService() {
+        Map<String, Object> outputs;
+
+        outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
+        for (int i = 0; i < 10; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, false);
+        }
+        for (int i = 0; i < 90; i++) {
+            outputs = startAndReturnTaskOutputData("test item", "john", 5, true);
+        }
+
+        assertEquals("true", outputs.get("approved"));
+    }
+
+
+}

--- a/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/UnequalProbabilityTest.java
+++ b/jbpm-recommendation-smile-random-forest/src/test/java/org/jbpm/prediction/randomforest/UnequalProbabilityTest.java
@@ -32,6 +32,7 @@ public class UnequalProbabilityTest extends RandomForestPredictionServiceProcess
      */
     @Test
     public void testUnequalProbabilityRandomForestPredictionService() {
+        System.setProperty("org.jbpm.task.prediction.service.confidence_threshold", "1.0");
         Map<String, Object> outputs;
 
         outputs = startAndReturnTaskOutputData("test item", "john", 5, true);

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/BPMN2-UserTask.bpmn2
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/BPMN2-UserTask.bpmn2
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_ZXxk4PPIEei3vdSeFAookw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_itemItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_actorItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_levelItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_approvedItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputXItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputXItem" structureRef="Boolean"/>
+  <bpmn2:process id="UserTask" drools:packageName="com.myspace.project" drools:version="1.0" name="process" isExecutable="true">
+    <bpmn2:property id="actor" itemSubjectRef="_actorItem"/>
+    <bpmn2:property id="item" itemSubjectRef="_itemItem"/>
+    <bpmn2:property id="level" itemSubjectRef="_levelItem"/>
+    <bpmn2:property id="approved" itemSubjectRef="_approvedItem"/>
+    <bpmn2:sequenceFlow id="_7990B36D-F7C5-48D3-AD5B-69DC694E53A5" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B" targetRef="_3B67882C-C399-4963-907A-4A1EBFB7BE50"/>
+    <bpmn2:startEvent id="_F1177242-F8C7-4623-98A6-1CE014F68C0E" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_93FF521A-176E-4C9E-90E0-BC0B7411DC30</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Task">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_93FF521A-176E-4C9E-90E0-BC0B7411DC30</bpmn2:incoming>
+      <bpmn2:outgoing>_7990B36D-F7C5-48D3-AD5B-69DC694E53A5</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_ZXxk4fPIEei3vdSeFAookw">
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX" drools:dtype="String" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX" drools:dtype="String" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputXItem" name="item"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX" drools:dtype="Integer" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputXItem" name="level"/>
+        <bpmn2:dataInput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX" drools:dtype="Object" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputXItem" name="approved"/>
+        <bpmn2:inputSet id="_ZXxk4vPIEei3vdSeFAookw">
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_ZXxk4_PIEei3vdSeFAookw">
+          <bpmn2:dataOutputRefs>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_ZXxk5PPIEei3vdSeFAookw">
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_ZXxk5fPIEei3vdSeFAookw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_ZXxk5vPIEei3vdSeFAookw"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_ZXyL8PPIEei3vdSeFAookw">_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8fPIEei3vdSeFAookw">
+        <bpmn2:sourceRef>item</bpmn2:sourceRef>
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_itemInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8vPIEei3vdSeFAookw">
+        <bpmn2:sourceRef>level</bpmn2:sourceRef>
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_levelInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_ZXyL8_PIEei3vdSeFAookw">
+        <bpmn2:targetRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_ZXyL9PPIEei3vdSeFAookw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_ZXyL9fPIEei3vdSeFAookw">false</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_ZXyL9vPIEei3vdSeFAookw">_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_ZXyL9_PIEei3vdSeFAookw">
+        <bpmn2:sourceRef>_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B_approvedOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>approved</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:potentialOwner id="_ZXyL-PPIEei3vdSeFAookw">
+        <bpmn2:resourceAssignmentExpression id="_ZXyL-fPIEei3vdSeFAookw">
+          <bpmn2:formalExpression id="_ZXyL-vPIEei3vdSeFAookw">#{actor}</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="_3B67882C-C399-4963-907A-4A1EBFB7BE50" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_7990B36D-F7C5-48D3-AD5B-69DC694E53A5</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_93FF521A-176E-4C9E-90E0-BC0B7411DC30" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F1177242-F8C7-4623-98A6-1CE014F68C0E" targetRef="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_ZXyL-_PIEei3vdSeFAookw">
+    <bpmndi:BPMNPlane id="_ZXyL_PPIEei3vdSeFAookw" bpmnElement="UserTask">
+      <bpmndi:BPMNShape id="_ZXyL_fPIEei3vdSeFAookw" bpmnElement="_F1177242-F8C7-4623-98A6-1CE014F68C0E">
+        <dc:Bounds height="30.0" width="30.0" x="105.0" y="113.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ZXyL_vPIEei3vdSeFAookw" bpmnElement="_7D6B6D7B-4382-4FD3-A856-B947D0ACD89B">
+        <dc:Bounds height="102.0" width="154.0" x="225.0" y="77.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ZXyL__PIEei3vdSeFAookw" bpmnElement="_3B67882C-C399-4963-907A-4A1EBFB7BE50">
+        <dc:Bounds height="28.0" width="28.0" x="459.0" y="114.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_ZXyMAPPIEei3vdSeFAookw" bpmnElement="_7990B36D-F7C5-48D3-AD5B-69DC694E53A5" sourceElement="_ZXyL_vPIEei3vdSeFAookw" targetElement="_ZXyL__PIEei3vdSeFAookw">
+        <di:waypoint xsi:type="dc:Point" x="302.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="473.0" y="128.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ZXyMAfPIEei3vdSeFAookw" bpmnElement="_93FF521A-176E-4C9E-90E0-BC0B7411DC30" sourceElement="_ZXyL_fPIEei3vdSeFAookw" targetElement="_ZXyL_vPIEei3vdSeFAookw">
+        <di:waypoint xsi:type="dc:Point" x="120.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="302.0" y="128.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <jta-data-source>jdbc/testDS1</jta-data-source>
+        <mapping-file>META-INF/Taskorm.xml</mapping-file>
+        <mapping-file>META-INF/JBPMorm.xml</mapping-file>
+        <mapping-file>META-INF/Servicesorm.xml</mapping-file>
+        <mapping-file>META-INF/TaskAuditorm.xml</mapping-file>
+
+        <class>org.jbpm.services.task.impl.model.AttachmentImpl</class>
+        <class>org.jbpm.services.task.impl.model.ContentImpl</class>
+        <class>org.jbpm.services.task.impl.model.BooleanExpressionImpl</class>
+        <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+        <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+        <class>org.jbpm.services.task.impl.model.DelegationImpl</class>
+        <class>org.jbpm.services.task.impl.model.EscalationImpl</class>
+        <class>org.jbpm.services.task.impl.model.GroupImpl</class>
+        <class>org.jbpm.services.task.impl.model.I18NTextImpl</class>
+        <class>org.jbpm.services.task.impl.model.NotificationImpl</class>
+        <class>org.jbpm.services.task.impl.model.EmailNotificationImpl</class>
+        <class>org.jbpm.services.task.impl.model.EmailNotificationHeaderImpl</class>
+        <class>org.jbpm.services.task.impl.model.PeopleAssignmentsImpl</class>
+        <class>org.jbpm.services.task.impl.model.ReassignmentImpl</class>
+
+        <class>org.jbpm.services.task.impl.model.TaskImpl</class>
+        <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
+        <class>org.jbpm.services.task.impl.model.UserImpl</class>
+
+
+        <class>org.drools.persistence.info.SessionInfo</class>
+        <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+        <class>org.drools.persistence.info.WorkItemInfo</class>
+        <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+        <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+        <!-- manager -->
+        <class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+
+        <!-- bam -->
+        <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+        <class>org.jbpm.process.audit.NodeInstanceLog</class>
+        <class>org.jbpm.process.audit.VariableInstanceLog</class>
+
+        <!--BAM for task service -->
+        <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>
+
+        <!-- Event Classes -->
+        <class>org.jbpm.services.task.audit.impl.model.TaskEventImpl</class>
+
+        <!-- Task Audit Classes -->
+        <class>org.jbpm.services.task.audit.impl.model.AuditTaskImpl</class>
+        <class>org.jbpm.services.task.audit.impl.model.TaskVariableImpl</class>
+
+        <!-- deployment store -->
+        <class>org.jbpm.kie.services.impl.store.DeploymentStoreEntry</class>
+
+        <!--  query service storage -->
+        <class>org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity</class>
+
+        <!-- error handling -->
+        <class>org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo</class>
+
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.connection.autocommit" value="false"/>
+
+            <property name="hibernate.max_fetch_depth" value="3"/>
+            <property name="hibernate.hbm2ddl.auto" value="create"/>
+            <property name="hibernate.show_sql" value="false"/>
+
+
+            <property name="hibernate.transaction.manager_lookup_class"
+                      value="org.hibernate.transaction.BTMTransactionManagerLookup"/>
+
+            <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
+            <property name="hibernate.id.new_generator_mappings" value="false"/>
+            <property name="hibernate.connection.release_mode" value="after_transaction"/>
+        </properties>
+    </persistence-unit>
+
+
+</persistence>

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/inputs.properties
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/inputs.properties
@@ -1,0 +1,3 @@
+item=NOMINAL
+ActorId=NOMINAL
+level=NOMINAL

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/jndi.properties
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/jndi.properties
@@ -1,0 +1,4 @@
+java.naming.factory.initial=org.jbpm.test.util.CloseSafeMemoryContextFactory
+org.osjava.sj.root=target/test-classes/config
+org.osjava.jndi.delimiter=/
+org.osjava.sj.jndi.shared=true

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/jndi.properties
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/jndi.properties
@@ -1,4 +1,0 @@
-java.naming.factory.initial=org.jbpm.test.util.CloseSafeMemoryContextFactory
-org.osjava.sj.root=target/test-classes/config
-org.osjava.jndi.delimiter=/
-org.osjava.sj.jndi.shared=true

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/logback-test.xml
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- %l lowers performance -->
+            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+            <pattern>%d [%t|%C] %-5p %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.arjuna" level="error"/>
+    <logger name="org.hibernate" level="warn"/>
+    <logger name="org.hibernate.tool.hbm2ddl.SchemaExport" level="off"/>
+
+    <logger name="org.jbpm.services.task.wih" level="warn"/>
+    <logger name="org.jbpm.services.task.impl" level="info"/>
+    <logger name="org.jbpm.prediction.randomforest" level="debug"/>
+
+    <logger name="org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl" level="error"/>
+    <root level="warn">
+        <appender-ref ref="consoleAppender"/>
+    </root>
+
+</configuration>

--- a/jbpm-recommendation-smile-random-forest/src/test/resources/output.properties
+++ b/jbpm-recommendation-smile-random-forest/src/test/resources/output.properties
@@ -1,0 +1,4 @@
+name=approved
+type=NOMINAL
+confidence_threshold=1.0
+num_trees=100


### PR DESCRIPTION
Added the following prediction service example implementations:

* SMILE-based random forest
* SMILE-based naïve Bayes