### PR TITLE
[JBPM-9132] Support authentication token for the Seldon prediction API example

### DIFF
--- a/jbpm-seldon-prediction-service/src/main/java/org/jbpm/prediction/service/seldon/payload/AuthorizationTokenFilter.java
+++ b/jbpm-seldon-prediction-service/src/main/java/org/jbpm/prediction/service/seldon/payload/AuthorizationTokenFilter.java
@@ -1,0 +1,19 @@
+package org.jbpm.prediction.service.seldon.payload;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.io.IOException;
+
+public class AuthorizationTokenFilter implements ClientRequestFilter {
+
+    private final String token;
+
+    public AuthorizationTokenFilter(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add("Authorization", "Bearer " + token);
+    }
+}

--- a/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/AbstractSeldonTestSuite.java
+++ b/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/AbstractSeldonTestSuite.java
@@ -29,12 +29,13 @@ import org.kie.internal.query.QueryFilter;
 
 import java.util.*;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertNotNull;
 
 public class AbstractSeldonTestSuite extends AbstractKieServicesTest {
 
     @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(5000);
+    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig().extensions(new AuthTokenRequestFilter()).port(5000));
 
     @Rule
     public WireMockClassRule instanceRule = wireMockRule;
@@ -45,6 +46,7 @@ public class AbstractSeldonTestSuite extends AbstractKieServicesTest {
     public static void setupOnce() {
         System.setProperty("org.jbpm.task.prediction.service", ExampleSeldonPredictionService.IDENTIFIER);
         System.setProperty("org.jbpm.task.prediction.service.seldon.url", "http://localhost:5000");
+        System.setProperty("org.jbpm.task.prediction.service.seldon.token", "foobar");
     }
 
     @AfterClass

--- a/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/AuthTokenRequestFilter.java
+++ b/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/AuthTokenRequestFilter.java
@@ -1,0 +1,24 @@
+package org.jbpm.prediction.service.seldon;
+
+import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilterAction;
+import com.github.tomakehurst.wiremock.extension.requestfilter.StubRequestFilter;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+
+public class AuthTokenRequestFilter extends StubRequestFilter {
+
+    @Override
+    public RequestFilterAction filter(Request request) {
+        if (request.header("Authorization").firstValue().equals("Bearer foobar")) {
+            return RequestFilterAction.continueWith(request);
+        }
+
+        return RequestFilterAction.stopWith(ResponseDefinition.notAuthorised());
+
+    }
+
+    @Override
+    public String getName() {
+        return "bearer";
+    }
+}

--- a/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/NDArrayResponseTest.java
+++ b/jbpm-seldon-prediction-service/src/test/java/org/jbpm/prediction/service/seldon/NDArrayResponseTest.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.prediction.service.seldon;
 
+
 import org.junit.Test;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ public class NDArrayResponseTest extends AbstractSeldonTestSuite {
     public void testNDArrayResponse() {
         stubFor(post(urlEqualTo("/predict"))
                 .withHeader("Accept", equalTo("application/json"))
+
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Add authorization token to requests.